### PR TITLE
Split TXT record KV pair and propagate BString type value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ async-std = { optional = true, version = "1.6.2", features = ["unstable", "attri
 tokio = {optional = true, version = "1.8", features = ["time", "net", "rt-multi-thread", "macros"]}
 tokio-stream = {optional = true, version = "0.1.8", features = ["time"]}
 serde = {optional = true, version = "1", features = ["derive"]}
-
+unicase="2.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 rust-version = "1.58.1"
 name = "mdns"
-version = "4.0.0"
+version = "5.0.0"
 authors = ["Dylan McKay <me@dylanmckay.io>"]
 edition = "2021"
 
@@ -25,6 +25,7 @@ runtime-tokio = ["tokio", "tokio-stream"]
 with-serde = ["serde"]
 
 [dependencies]
+bstr = "0.2.17"
 dns-parser = "0.8.0"
 net2 = "0.2"
 err-derive = "0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ compile_error!("\"runtime-async-std\" and \"runtime-tokio\" cannot be enabled si
 compile_error!("At least one runtime (\"runtime-async-std\" or \"runtime-tokio\") cargo feature must be enabled");
 
 pub use self::errors::Error;
-pub use self::response::{Record, RecordKind, Response};
+pub use self::response::{Record, RecordKind, Response, TxtRecordValue};
 
 pub mod discover;
 pub mod resolve;

--- a/src/response.rs
+++ b/src/response.rs
@@ -172,7 +172,7 @@ pub(crate) mod serde_helpers {
         {
             let mut map = serializer.serialize_map(Some(records.len()))?;
             for (k, v) in records {
-                map.serialize_entry(&k.to_string(), v)?;
+                map.serialize_entry(&k.as_ref(), v)?;
             }
             map.end()
         }

--- a/src/response.rs
+++ b/src/response.rs
@@ -69,6 +69,7 @@ pub enum TxtRecordValue {
 /// Case is ignored when interpreting a key,
 /// so "papersize=A4", "PAPERSIZE=A4", and "Papersize=A4" are all identical.
 #[derive(Eq, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 pub struct TxtRecordKey(String);
 
 impl Hash for TxtRecordKey {


### PR DESCRIPTION
Following TXT Record format for DNS-SD detailed in [RFC 6763](https://datatracker.ietf.org/doc/html/rfc6763#section-6.3), an attribute contains a (key, value) pairing where value is an opaque binary data. 
The spec also differentiates no-value attribute (`key`) from empty-value attribute (`key=`). 
The keys are mandated to be unique in a service type context, and duplicates in a single TXT record are suggested to be silently ignored.

As such, this PR makes the following changes:
- Split the TXT record into key value pairs
- Use HashMap instead of Vector of TXT records
- Define an explicit enum for TXT record value type
- Propagate BString value, avoiding lossy translation to UTF-8 string